### PR TITLE
Improve statement cache perf by using `rustc-hash` instead of the `std` hasher.

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -20,11 +20,16 @@ rt_async-std_1 = ["deadpool/rt_async-std_1"]
 serde = ["deadpool/serde", "serde_1"]
 
 [dependencies]
-deadpool = { path = "../", version = "0.9.0", default-features = false, features = ["managed"] }
+deadpool = { path = "../", version = "0.9.0", default-features = false, features = [
+    "managed",
+] }
 log = "0.4"
-serde_1 = { package = "serde", version = "1.0", features = ["derive"], optional = true }
+serde_1 = { package = "serde", version = "1.0", features = [
+    "derive",
+], optional = true }
 tokio = { version = "1", features = ["rt"] }
 tokio-postgres = "0.7.2"
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 config = { version = "0.13", features = ["json"] }

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -25,7 +25,6 @@ mod generic_client;
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
     fmt,
     ops::{Deref, DerefMut},
     sync::{
@@ -35,6 +34,7 @@ use std::{
 };
 
 use deadpool::{async_trait, managed};
+use rustc_hash::FxHashMap;
 use tokio::spawn;
 use tokio_postgres::{
     tls::MakeTlsConnect, tls::TlsConnect, types::Type, Client as PgClient, Config as PgConfig,
@@ -266,14 +266,14 @@ struct StatementCacheKey<'a> {
 /// and [`ClientWrapper::prepare_typed_cached()`] methods instead (or the
 /// similar ones on [`Transaction`]).
 pub struct StatementCache {
-    map: RwLock<HashMap<StatementCacheKey<'static>, Statement>>,
+    map: RwLock<FxHashMap<StatementCacheKey<'static>, Statement>>,
     size: AtomicUsize,
 }
 
 impl StatementCache {
     fn new() -> Self {
         Self {
-            map: RwLock::new(HashMap::new()),
+            map: RwLock::new(FxHashMap::default()),
             size: AtomicUsize::new(0),
         }
     }


### PR DESCRIPTION
This is just a POC PR to show how the implementation could be done.

This only affects PostgreSQL, I couldn't find statement caches for the other drivers.

AFAIK, this change is non-breaking and doesn't have any API repercussions. `FxHashMap` is just a convenience type alias, it uses `HashMap` under the hood.

I'm not familiar enough with the internals of the crate to know if the current benchmarks take statement cache hashing into account, so it's hard to tell the actual real-use gains. If you think this would be necessary and could provide guidance, I could improve the PR with proper benchmarking.

I have benchmarked the hashing algorithms alone head-to-head, and `rustc-hash` performs 20% to 50% better than the std algorithm on plausible SQL queries. FxHash is particularly faster on smaller inputs. `rust-hash` is well-known to be faster, but it doesn't have DoS-safety like the std hasher has. This shouldn't be a problem since usually the app controls which queries are hashed.

## Why
Improve statement cache hashing performance without changing the API.

## Alternatives
Keep using the std hasher.

## Future work
The hashing algorithm is a small change with a small impact, but there are other ways to speed up the statement caches.

I noticed that there's a lot of `RwLock` and `Mutex` going on in the internals of the statement caches implementation. I reckon we could make significant gains using some sort of lock-free/concurrent datastructures. Most async projects are multithreaded (e.g. tokio distributes tasks on many cores if possible), so this should provide significant performance gains. I'd like to explore this in a future PR.