### PR TITLE
Add RecyclingMethod to `deadpool-redis`

### DIFF
--- a/redis/src/cluster/config.rs
+++ b/redis/src/cluster/config.rs
@@ -47,6 +47,11 @@ pub struct Config {
     /// [`redis::ConnectionInfo`] structures.
     pub connections: Option<Vec<ConnectionInfo>>,
 
+    /// [`Manager`] configuration.
+    ///
+    /// [`Manager`]: super::Manager
+    pub manager: Option<ManagerConfig>,
+
     /// Pool configuration.
     pub pool: Option<PoolConfig>,
 
@@ -114,6 +119,7 @@ impl Config {
         Config {
             urls: Some(urls.into()),
             connections: None,
+            manager: None,
             pool: None,
             read_from_replicas: false,
         }
@@ -125,6 +131,7 @@ impl Default for Config {
         Self {
             urls: None,
             connections: Some(vec![ConnectionInfo::default()]),
+            manager: None,
             pool: None,
             read_from_replicas: false,
         }

--- a/redis/src/config.rs
+++ b/redis/src/config.rs
@@ -45,6 +45,11 @@ pub struct Config {
     /// [`redis::ConnectionInfo`] structure.
     pub connection: Option<ConnectionInfo>,
 
+    /// [`Manager`] configuration.
+    ///
+    /// [`Manager`]: super::Manager
+    pub manager: Option<ManagerConfig>,
+
     /// Pool configuration.
     pub pool: Option<PoolConfig>,
 }
@@ -93,6 +98,7 @@ impl Config {
         Config {
             url: Some(url.into()),
             connection: None,
+            manager: None,
             pool: None,
         }
     }
@@ -104,6 +110,7 @@ impl Config {
         Config {
             url: None,
             connection: Some(connection_info.into()),
+            manager: None,
             pool: None,
         }
     }
@@ -114,6 +121,7 @@ impl Default for Config {
         Self {
             url: None,
             connection: Some(ConnectionInfo::default()),
+            manager: None,
             pool: None,
         }
     }
@@ -328,3 +336,32 @@ impl fmt::Display for ConfigError {
 }
 
 impl std::error::Error for ConfigError {}
+
+/// Configuration object for a [`Manager`].
+///
+/// This currently only makes it possible to specify which [`RecyclingMethod`]
+/// should be used when retrieving existing objects from the [`Pool`].
+///
+/// [`Manager`]: super::Manager
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct ManagerConfig {
+    /// Method of how a connection is recycled. See [`RecyclingMethod`].
+    pub recycling_method: RecyclingMethod,
+}
+
+/// Possible methods of how a connection is recycled.
+///
+/// The default is [`Fast`] which does not check the connection health or
+/// perform any clean-up queries.
+///
+/// [`Fast`]: RecyclingMethod::Fast
+/// [`Verified`]: RecyclingMethod::Verified
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum RecyclingMethod {
+    /// Run `UNWATCH` to discard transaction state, then send a ping to verify
+    /// the connection is still alive.
+    #[default]
+    Clean,
+}

--- a/redis/src/sentinel/config.rs
+++ b/redis/src/sentinel/config.rs
@@ -57,6 +57,12 @@ pub struct Config {
     pub connections: Option<Vec<ConnectionInfo>>,
     /// [`redis::sentinel::SentinelNodeConnectionInfo`] structures.
     pub node_connection_info: Option<SentinelNodeConnectionInfo>,
+
+    /// [`Manager`] configuration.
+    ///
+    /// [`Manager`]: super::Manager
+    pub manager: Option<ManagerConfig>,
+
     /// Pool configuration.
     pub pool: Option<PoolConfig>,
 }
@@ -123,11 +129,12 @@ impl Config {
     ) -> Config {
         Config {
             urls: Some(urls.into()),
-            connections: None,
-            master_name,
             server_type,
-            pool: None,
+            master_name,
+            connections: None,
             node_connection_info: None,
+            manager: None,
+            pool: None,
         }
     }
 
@@ -150,11 +157,12 @@ impl Default for Config {
 
         Self {
             urls: None,
-            connections: Some(vec![default_connection_info.clone()]),
             server_type: SentinelServerType::Master,
             master_name: default_master_name(),
-            pool: None,
+            connections: Some(vec![default_connection_info.clone()]),
             node_connection_info: None,
+            manager: None,
+            pool: None,
         }
     }
 }


### PR DESCRIPTION
This change adds a new `RecyclingMethod` enum to `deadpool-redis`, which can be used to clean up subscriptions when recycling connections.

Also removing the support for configuring Redis connections via `AsyncConnectionConfig`. Part of the plan in https://github.com/deadpool-rs/deadpool/issues/226

Let me know if there's any other way I could help! (Not sure if you had these changes in another branch also, if that's the case happy to look at that and try to work off of your existing changes.)