### PR TITLE
Add CI phase for documentation of 'deadpool-r2d2'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,7 @@ jobs:
           - deadpool-postgres
           - deadpool-redis
           - deadpool-sqlite
+          - deadpool-r2d2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Small fix (unless there was a reason for not having this 🤔) discovered as I was playing around the CI file.