### PR TITLE
Update config dev-dependency from 0.14 to 0.15 (everywhere)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.0", features = ["sync"] }
 
 [dev-dependencies]
 async-std = { version = "1.0", features = ["attributes"] }
-config = { version = "0.14", features = ["json"] }
+config = { version = "0.15", features = ["json"] }
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 itertools = "0.13"
 tokio = { version = "1.5.0", features = [

--- a/examples/postgres-actix-web/Cargo.toml
+++ b/examples/postgres-actix-web/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 actix-web = "4.0.1"
-config = "0.14"
+config = "0.15"
 deadpool-postgres = { path = "../../postgres", features = ["serde"] }
 dotenvy = "0.15"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/postgres-axum/Cargo.toml
+++ b/examples/postgres-axum/Cargo.toml
@@ -12,5 +12,5 @@ tokio-postgres = { version = "0.7.10", features = ["with-uuid-1"] }
 dotenvy = "0.15.7"
 uuid = { version = "1.8.0", features = ["serde"] }
 serde = { version = "1.0.200", features = ["derive"] }
-config = "0.14.0"
+config = "0.15.0"
 axum-macros = "0.4.1"

--- a/examples/postgres-benchmark/Cargo.toml
+++ b/examples/postgres-benchmark/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 publish = false
 
 [dependencies]
-config = "0.14"
+config = "0.15"
 deadpool-postgres = { path = "../../postgres", features = ["serde"] }
 dotenvy = "0.15"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/postgres-hyper/Cargo.toml
+++ b/examples/postgres-hyper/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 publish = false
 
 [dependencies]
-config = "0.14"
+config = "0.15"
 deadpool-postgres = { path = "../../postgres", features = ["serde"] }
 dotenvy = "0.15"
 hyper = { version = "0.14", features = ["http1", "http2", "server", "runtime"] }

--- a/lapin/Cargo.toml
+++ b/lapin/Cargo.toml
@@ -48,7 +48,7 @@ tokio-executor-trait = { version = "2.1.0", optional = true }
 async-global-executor = { version = "2.3.1", optional = true, default-features = false }
 
 [dev-dependencies]
-config = { version = "0.14", features = ["json"] }
+config = { version = "0.15", features = ["json"] }
 dotenvy = "0.15"
 tokio = { version = "1.0", features = ["sync", "macros", "rt-multi-thread"] }
 

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -59,7 +59,7 @@ getrandom = { version = "0.2", features = ["js"] }
 tokio-postgres = { version = "0.7.9", default-features = false }
 
 [dev-dependencies]
-config = { version = "0.14", features = ["json"] }
+config = { version = "0.15", features = ["json"] }
 dotenvy = "0.15.0"
 futures = "0.3.1"
 futures-util = "0.3.30"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -60,7 +60,7 @@ serde = { package = "serde", version = "1.0", features = [
 tokio = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
-config = { version = "0.14", features = ["json"] }
+config = { version = "0.15", features = ["json"] }
 dotenvy = "0.15.0"
 futures = "0.3.15"
 redis = { version = "0.29", default-features = false, features = [

--- a/sqlite/Cargo.toml
+++ b/sqlite/Cargo.toml
@@ -67,5 +67,5 @@ serde = { package = "serde", version = "1.0", features = [
 ], optional = true }
 
 [dev-dependencies]
-config = { version = "0.14", features = ["json"] }
+config = { version = "0.15", features = ["json"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
This doesn’t *seem* to cause any regressions.

List of breaking changes from 0.14 to 0.15: https://github.com/rust-cli/config-rs/blob/v0.15.11/CHANGELOG.md#0150---2024-12-17