### PR TITLE
chore: Upgrade redis dependency to 0.32.2

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -53,7 +53,7 @@ cache-aio = ["redis/cache-aio"]
 deadpool = { path = "../", version = "0.12.0", default-features = false, features = [
     "managed",
 ] }
-redis = { version = "0.31", default-features = false, features = ["aio"] }
+redis = { version = "0.32.2", default-features = false, features = ["aio"] }
 serde = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }
@@ -63,7 +63,7 @@ tokio = { version = "1.0", default-features = false, optional = true }
 config = { version = "0.15", features = ["json"] }
 dotenvy = "0.15.0"
 futures = "0.3.15"
-redis = { version = "0.31", default-features = false, features = [
+redis = { version = "0.32.2", default-features = false, features = [
     "tokio-comp",
 ] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "sync"] }


### PR DESCRIPTION
Diff: https://github.com/redis-rs/redis-rs/compare/redis-0.31.0...redis-0.32.2