### PR TITLE
feat(deadpool): cache num_cpus for better init performance

### DIFF
--- a/crates/deadpool/CHANGELOG.md
+++ b/crates/deadpool/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add unique `id` to objects which can be read via the `Object::id` method
 - Add `WeakPool<T>` and `Pool::weak()` for non-owning, upgradeable pool references.
+- Cache `num_cpus::get_physical()` result to improve `Pool` creation performance.
 
 ## [0.12.2] - 2025-02-02
 

--- a/crates/deadpool/Cargo.toml
+++ b/crates/deadpool/Cargo.toml
@@ -22,6 +22,7 @@ rt_tokio_1 = ["deadpool-runtime/tokio_1"]
 rt_async-std_1 = ["deadpool-runtime/async-std_1"]
 
 [dependencies]
+lazy_static = "1.5.0"
 num_cpus = "1.11.1"
 # `serde` feature
 serde = { version = "1.0.103", features = ["derive"], optional = true }

--- a/crates/deadpool/src/lib.rs
+++ b/crates/deadpool/src/lib.rs
@@ -54,3 +54,5 @@ pub struct Status {
     /// The number of futures waiting for an object.
     pub waiting: usize,
 }
+
+mod util;

--- a/crates/deadpool/src/managed/config.rs
+++ b/crates/deadpool/src/managed/config.rs
@@ -51,7 +51,7 @@ impl Default for PoolConfig {
     /// Creates a new [`PoolConfig`] with the `max_size` being set to
     /// `cpu_count * 4` ignoring any logical CPUs (Hyper-Threading).
     fn default() -> Self {
-        Self::new(num_cpus::get_physical() * 4)
+        Self::new(crate::util::get_default_pool_max_size())
     }
 }
 

--- a/crates/deadpool/src/unmanaged/config.rs
+++ b/crates/deadpool/src/unmanaged/config.rs
@@ -35,6 +35,6 @@ impl Default for PoolConfig {
     /// Create a [`PoolConfig`] where [`PoolConfig::max_size`] is set to
     /// `cpu_count * 4` ignoring any logical CPUs (Hyper-Threading).
     fn default() -> Self {
-        Self::new(num_cpus::get_physical() * 4)
+        Self::new(crate::util::get_default_pool_max_size())
     }
 }

--- a/crates/deadpool/src/util.rs
+++ b/crates/deadpool/src/util.rs
@@ -1,0 +1,16 @@
+lazy_static::lazy_static! {
+    /// Cache the physical CPU count to avoid calling `num_cpus::get_physical`
+    /// multiple times, which is expensive.
+    ///
+    /// TODO: in container environment, we should use the cpus limit of the container
+    /// instead of the number of physical CPUs. Thus, we should call `num_cpus::get()`
+    /// instead of `num_cpus::get_physical()`, which is aware of cgroup. This may be
+    /// a breaking change so we don't do it for now.
+    static ref PHYSICAL_CPU_COUNT: usize = num_cpus::get_physical();
+}
+
+/// Get the default maximum size of a pool, which is `cpu_count * 4` ignoring
+/// any logical CPUs (Hyper-Threading).
+pub(crate) fn get_default_pool_max_size() -> usize {
+    *PHYSICAL_CPU_COUNT * 4
+}


### PR DESCRIPTION
On Linux environment, calling `num_cpus::get_physical()` costs about 1-2ms per time, and in our scenario, we need to create hundreds to thousands of `Pool`s dynamically(our services normally have hundreds to thousands of instances).

Thus, it will cost a really long time to create the pools, which lead to service hang or request timeout.

This PR caches the result of `num_cpus::get_physical` to avoid calling it every time, which can greatly improve the `new` performance of `Pool`.

Also, in container environment, we should call `num_cpus::get()` instead of `num_cpus::get_physical()`, but since it may be a breaking change, I only added an TODO for it. 

PTAL, thanks!