### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/crates/deadpool/Cargo.toml
+++ b/crates/deadpool/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "deadpool"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.80"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool"
 keywords = ["async", "database", "pool"]
@@ -22,7 +22,6 @@ rt_tokio_1 = ["deadpool-runtime/tokio_1"]
 rt_async-std_1 = ["deadpool-runtime/async-std_1"]
 
 [dependencies]
-lazy_static = "1.5.0"
 num_cpus = "1.11.1"
 # `serde` feature
 serde = { version = "1.0.103", features = ["derive"], optional = true }
@@ -36,7 +35,7 @@ tokio = { version = "1.5", features = ["sync"] }
 [dev-dependencies]
 async-std = { version = "1.0", features = ["attributes"] }
 config = { version = "0.15", features = ["json"] }
-criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
+criterion = { version = "0.7", features = ["html_reports", "async_tokio"] }
 itertools = "0.14"
 tokio = { version = "1.5.0", features = [
     "macros",

--- a/crates/deadpool/src/util.rs
+++ b/crates/deadpool/src/util.rs
@@ -1,9 +1,9 @@
-lazy_static::lazy_static! {
-    /// Cache the physical CPU count to avoid calling `num_cpus::get()`
-    /// multiple times, which is expensive when creating pools in quick
-    /// succession.
-    static ref CPU_COUNT: usize = num_cpus::get();
-}
+use std::sync::LazyLock;
+
+/// Cache the physical CPU cofunt to avoid calling `num_cpus::get()`
+/// multiple times, which is expensive when creating pools in quick
+/// succession.
+static CPU_COUNT: LazyLock<usize> = LazyLock::new(num_cpus::get);
 
 /// Get the default maximum size of a pool, which is `cpu_core_count * 2`
 /// including logical cores (Hyper-Threading).


### PR DESCRIPTION
By bumping the rust version to 1.80, the dependency on lazy_static becomes obsolete, see [their docs](https://github.com/rust-lang-nursery/lazy-static.rs?tab=readme-ov-file#standard-library). It can be replaced with [std::sync::LazyLock](https://doc.rust-lang.org/std/sync/struct.LazyLock.html)